### PR TITLE
Fix wrong panel item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.1 - Fixed Wrong pane item
+* When opened tab is not TextEditor (e.g. About page) opening new file crashes
+
 ## 0.2.0 - Smooth Scroll
 * j, k, J, K, C-J, C-K, gg and G will now smoothly scroll
 * Fixed the issue with hidden files begin selected when moving with keyboard

--- a/lib/nerd-treeview.coffee
+++ b/lib/nerd-treeview.coffee
@@ -88,7 +88,7 @@ module.exports =
             return treeView.openSelectedEntry(activate)
 
         item = activePane.getActiveItem()
-        replace = item and !item.isModified()
+        replace = item and !item.isModified?()
 
         same = false
         for paneItem in activePane.getItems()

--- a/lib/nerd-treeview.coffee
+++ b/lib/nerd-treeview.coffee
@@ -92,7 +92,7 @@ module.exports =
 
         same = false
         for paneItem in activePane.getItems()
-            if (selected.getPath() == paneItem.getPath())
+            if (selected.getPath() == paneItem.getPath?())
                 same = true
                 break
 


### PR DESCRIPTION
When opened tab is not TextEditor (e.g. About page) opening new file crashes. fixes #1 
