### PR TITLE
Replace deprecated reference

### DIFF
--- a/lib/nerd-treeview.coffee
+++ b/lib/nerd-treeview.coffee
@@ -24,7 +24,7 @@ module.exports =
         atom.commands.add('body', {
             'nerd-treeview:toggle': =>
                 if not @delegate('toggle')
-                    atom.commands.dispatch(workspaceView, 'tree-view:toggle')
+                    atom.commands.dispatch(atom.views.getView(atom.workspace), 'tree-view:toggle')
             'nerd-treeview:reveal-active-file': =>
                 @delegate('revealActiveFile')
             'nerd-treeview:toggle-focus': =>


### PR DESCRIPTION
`atom.workspaceView` is deprecated. This updates the package to use the latest API. Fixes #6.

https://atom.io/docs/api/v1.6.0/ViewRegistry#getting-the-workspace-element
