### PR TITLE
Fix stay commands

### DIFF
--- a/lib/nerd-treeview.coffee
+++ b/lib/nerd-treeview.coffee
@@ -160,7 +160,7 @@ module.exports =
         @clearPrefix()
 
         return if not treeView = @getTreeView()
-        activePane = atom.workspace.getActivePane()
+        activePane = atom.workspace.getCenter().getActivePane()
 
         selected = treeView.selectedEntry()
         if not $(selected).is('.file')

--- a/lib/nerd-treeview.coffee
+++ b/lib/nerd-treeview.coffee
@@ -166,8 +166,7 @@ module.exports =
         if not $(selected).is('.file')
             return treeView.openSelectedEntry({activatePane})
 
-        treeView.unfocus()
-        item = atom.workspace.getActivePaneItem()
+        item = atom.workspace.getCenter().getActivePaneItem()
         replace = item and !item.isModified?()
 
         same = false

--- a/lib/nerd-treeview.coffee
+++ b/lib/nerd-treeview.coffee
@@ -197,7 +197,7 @@ module.exports =
         return if not treeView = @getTreeView()
         treeView.openSelectedEntry({activatePane})
 
-        activePane = atom.workspace.getActivePane()
+        activePane = atom.workspace.getCenter().getActivePane()
         item = activePane.getActiveItem()
         if item
             selected = treeView.selectedEntry()


### PR DESCRIPTION
Fixes #20, #21, and #24. Repair the following stay commands by utilizing the proper [API](https://atom.io/docs/api/v1.19.0/Workspace#instance-getCenter) to find the active "center" pane item, rather than blurring the tree view.

- `nerd-treeview:open-stay`
- `nerd-treeview:open-tab-stay`
- `nerd-treeview:add-tab-stay`

The following stay commands remain broken for unrelated reasons.

- `nerd-treeview:open-split-vertical-stay`
- `nerd-treeview:open-split-horizontal-stay`